### PR TITLE
Fixed ReadMe URLs to point to @angular/router instead of @angular/upg…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,59 +10,37 @@ A repo that tests automatic detection of upstream publishes and the publishing o
 
 ## Latest Version
 
-### @angular/upgrade
+### @angular/router
 
 #### ES2015
 
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-upgrade.js
+https://cdn.jsdelivr.net/npm/@esm-bundle/angular__router/system/es2015/ivy/angular-router.js
 
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-upgrade.min.js
+https://cdn.jsdelivr.net/npm/@esm-bundle/angular__router/system/es2015/ivy/angular-router.min.js
 
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-upgrade.js
+https://unpkg.com/@esm-bundle/angular__router/system/es2015/ivy/angular-router.js
 
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-upgrade.min.js
-
-#### ES2020
-
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-upgrade.js
-
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-upgrade.min.js
-
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-upgrade.js
-
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-upgrade.min.js
-
-### @angular/upgrade/static
-
-#### ES2015
-
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-static.js
-
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-static.min.js
-
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-static.js
-
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2015/ivy/angular-static.min.js
+https://unpkg.com/@esm-bundle/angular__router/system/es2015/ivy/angular-router.min.js
 
 #### ES2020
 
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-static.js
+https://cdn.jsdelivr.net/npm/@esm-bundle/angular__router/system/es2020/ivy/angular-router.js
 
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-static.min.js
+https://cdn.jsdelivr.net/npm/@esm-bundle/angular__router/system/es2020/ivy/angular-router.min.js
 
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-static.js
+https://unpkg.com/@esm-bundle/angular__router/system/es2020/ivy/angular-router.js
 
-https://unpkg.com/@esm-bundle/angular__upgrade/system/es2020/ivy/angular-static.min.js
+https://unpkg.com/@esm-bundle/angular__router/system/es2020/ivy/angular-router.min.js
 
 ## Specific Version
 
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade@13.3.1/system/es2015/ivy/angular-upgrade.js
+https://cdn.jsdelivr.net/npm/@esm-bundle/angular__router@14.0.4/system/es2015/ivy/angular-router.js
 
-https://cdn.jsdelivr.net/npm/@esm-bundle/angular__upgrade@13.3.1/system/es2015/ivy/angular-upgrade.min.js
+https://cdn.jsdelivr.net/npm/@esm-bundle/angular__router@14.0.4/system/es2015/ivy/angular-router.js
 
-https://unpkg.com/@esm-bundle/angular__upgrade@13.3.1/system/es2015/ivy/angular-upgrade.js
+https://unpkg.com/@esm-bundle/angular__router@14.0.4/system/es2015/ivy/angular-router.js
 
-https://unpkg.com/@esm-bundle/angular__upgrade@13.3.1/system/es2015/ivy/angular-upgrade.min.js
+https://unpkg.com/@esm-bundle/angular__router@14.0.4/system/es2015/ivy/angular-router.min.js
 
 ## Need a build that doesn't exist yet?
 


### PR DESCRIPTION
Updated ReadMe URLs and verbiage to reflect `@angular/router` package instead of `@angular/upgrade`. Removed links to `@angular/upgrade/static`